### PR TITLE
test(coverage): increase test coverage to >90%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 15%
+        threshold: 5%
         base: auto
         flags:
           - unittests
@@ -24,7 +24,7 @@ component_management:
     statuses:
       - type: project
         target: auto
-        threshold: 15%
+        threshold: 5%
         informational: false
         if_ci_failed: error
   individual_components:

--- a/src/entities/post/api.test.ts
+++ b/src/entities/post/api.test.ts
@@ -88,4 +88,49 @@ describe('resolvePostsFromEntries', () => {
       '[content] Duplicate post slug detected: "2026-04-12-duplicate"'
     );
   });
+
+  it('uses default logContentIssue without throwing', () => {
+    const originalWrite = process.stderr.write;
+    const writeMock = vi.fn();
+    process.stderr.write = writeMock as any;
+
+    try {
+      resolvePostsFromEntries([['invalid.md', undefined]]);
+      expect(writeMock).toHaveBeenCalledWith(
+        expect.stringContaining('[content] Skipping invalid post "invalid.md": metadata is missing')
+      );
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+
+  it('reports missing metadata', () => {
+    const reportIssue = vi.fn();
+    resolvePostsFromEntries([['missing.md', undefined]], reportIssue);
+    expect(reportIssue).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping invalid post "missing.md": metadata is missing')
+    );
+  });
+
+  it('reports invalid updated date', () => {
+    const reportIssue = vi.fn();
+    resolvePostsFromEntries(
+      [
+        [
+          'bad-updated.md',
+          {
+            title: 'Test',
+            created: '2026-04-12',
+            tags: ['test'],
+            readingTime: 2,
+            updated: 'invalid-date',
+          } as any,
+        ],
+      ],
+      reportIssue
+    );
+    expect(reportIssue).toHaveBeenCalledWith(
+      expect.stringContaining('updated must be a valid ISO date string when provided')
+    );
+  });
 });

--- a/src/features/engine/core/Simulation.test.ts
+++ b/src/features/engine/core/Simulation.test.ts
@@ -28,19 +28,81 @@ describe('Simulation exhaustive logic', () => {
   it('wraps particles at field boundaries', () => {
     const sim = new Simulation(config);
     // Boundary is 10000 (FIELD constant). Particles wrap when x > FIELD or x < -FIELD.
-    sim.data[0] = 10001;
-    sim.data[1] = 500;
+    sim.data[0] = 10001; // x > FIELD
+    sim.data[1] = 10001; // y > FIELD
     sim.data[2] = 0; // stop movement to test only wrap
     sim.data[3] = 0;
 
     sim.step(16);
-    // 10001 > 10000 -> 10001 - 20000 = -9999
     expect(sim.data[0]).toBeLessThan(0);
+    expect(sim.data[1]).toBeLessThan(0);
 
-    sim.data[0] = -10001;
+    sim.data[0] = -10001; // x < -FIELD
+    sim.data[1] = -10001; // y < -FIELD
     sim.step(16);
-    // -10001 < -10000 -> -10001 + 20000 = 9999
     expect(sim.data[0]).toBeGreaterThan(0);
+    expect(sim.data[1]).toBeGreaterThan(0);
+  });
+
+  it('applies clickBurst correctly', () => {
+    const sim = new Simulation(config);
+    sim.data[0] = 505; // close to cursor
+    sim.data[1] = 500;
+    sim.data[2] = 0; // vx
+    sim.data[3] = 0; // vy
+
+    sim.clickBurst(500, 500, 100, 10);
+
+    // Particle should have gained velocity
+    expect(sim.data[2]).not.toBe(0);
+  });
+
+  it('interacts with cursor during step', () => {
+    const sim = new Simulation(config);
+    sim.setCursor(500, 500);
+    sim.data[0] = 505;
+    sim.data[1] = 500;
+    sim.data[2] = 0;
+    sim.data[3] = 0;
+
+    sim.step(16);
+
+    // Should have gained velocity due to cursor force
+    expect(sim.data[2]).not.toBe(0);
+
+    sim.clearCursor();
+  });
+
+  it('clamps speed if it exceeds maxSpeed', () => {
+    const sim = new Simulation(config);
+    sim.data[0] = 500;
+    sim.data[1] = 500;
+    sim.data[2] = 100; // huge vx
+    sim.data[3] = 100; // huge vy
+
+    sim.step(16);
+
+    const speed = Math.hypot(sim.data[2], sim.data[3]);
+    expect(speed).toBeLessThanOrEqual(config.speed * 1.5 * 1.01); // maxBaseSpeed * 1.5 + precision
+  });
+
+  it('skips triangles with high fade (distance near maxDist)', () => {
+    const sim = new Simulation({ ...config, count: 3 }); // 3 particles to force 1 triangle
+
+    // Place them in a triangle, but one edge is very long (distance > 143, maxDist is 150)
+    sim.data[0] = 0;
+    sim.data[1] = 0;
+    sim.data[8] = 145;
+    sim.data[9] = 0; // Distance 145
+    sim.data[16] = 72;
+    sim.data[17] = 10;
+
+    // Recompute edges
+    sim.step(16);
+
+    const { count } = sim.getTriangleData();
+    // Because fade is < 0.01 (145/150^2), it should skip the triangle
+    expect(count).toBe(0);
   });
 
   it('updates colors and recomputes edges', () => {

--- a/src/features/engine/passes/CompositePass.test.ts
+++ b/src/features/engine/passes/CompositePass.test.ts
@@ -1,33 +1,131 @@
-// @vitest-environment node
-import { describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CompositePass } from './CompositePass';
 
-const mockPipeline = {
-  getBindGroupLayout: vi.fn(() => ({})),
-};
-
-const mockTexture = {
-  createView: vi.fn(() => ({})),
-  destroy: vi.fn(),
-};
-
-const mockDevice = {
-  createShaderModule: vi.fn(() => ({})),
-  createRenderPipeline: vi.fn(async () => mockPipeline),
-  createBindGroup: vi.fn(() => ({})),
-  createBuffer: vi.fn(() => ({})),
-  createSampler: vi.fn(() => ({})),
-  createTexture: vi.fn(() => mockTexture),
-  queue: {
-    writeBuffer: vi.fn(),
-  },
-};
-
 describe('CompositePass', () => {
-  it('initializes pipelines', async () => {
-    const pass = new CompositePass();
-    // @ts-expect-error
+  let pass: CompositePass;
+  let mockDevice: any;
+  let mockEncoder: any;
+  let mockPassEncoder: any;
+  let mockTexture: any;
+  let mockBuffer: any;
+
+  beforeEach(() => {
+    pass = new CompositePass();
+
+    mockTexture = {
+      createView: vi.fn().mockReturnValue({}),
+      destroy: vi.fn(),
+    };
+
+    mockBuffer = {
+      destroy: vi.fn(),
+    };
+
+    const mockPipeline = {
+      getBindGroupLayout: vi.fn().mockReturnValue({}),
+    };
+
+    mockDevice = {
+      createShaderModule: vi.fn().mockReturnValue({}),
+      createRenderPipeline: vi.fn().mockResolvedValue(mockPipeline),
+      createSampler: vi.fn().mockReturnValue({}),
+      createBuffer: vi.fn().mockReturnValue(mockBuffer),
+      createTexture: vi.fn().mockReturnValue(mockTexture),
+      createBindGroup: vi.fn().mockReturnValue({}),
+      queue: {
+        writeBuffer: vi.fn(),
+      },
+    };
+
+    mockPassEncoder = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      draw: vi.fn(),
+      end: vi.fn(),
+    };
+
+    mockEncoder = {
+      beginRenderPass: vi.fn().mockReturnValue(mockPassEncoder),
+    };
+  });
+
+  it('initializes and creates offscreen resources', async () => {
     await pass.init(mockDevice, 'bgra8unorm', 800, 600);
-    expect(mockDevice.createRenderPipeline).toHaveBeenCalled();
+
+    expect(mockDevice.createShaderModule).toHaveBeenCalled();
+    expect(mockDevice.createRenderPipeline).toHaveBeenCalledTimes(2);
+    expect(mockDevice.createSampler).toHaveBeenCalled();
+    expect(mockDevice.createBuffer).toHaveBeenCalled();
+    expect(mockDevice.createTexture).toHaveBeenCalled();
+    expect(mockDevice.createBindGroup).toHaveBeenCalledTimes(3);
+
+    expect(pass.getOffscreenView()).toBeDefined();
+  });
+
+  it('resizes offscreen texture', async () => {
+    await pass.init(mockDevice, 'bgra8unorm', 800, 600);
+
+    mockTexture.destroy.mockClear();
+    pass.resize(mockDevice, 1024, 768);
+
+    expect(mockTexture.destroy).toHaveBeenCalled();
+    expect(mockDevice.createTexture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size: [1024, 768],
+      })
+    );
+  });
+
+  it('updates uniforms and writes to buffer', async () => {
+    await pass.init(mockDevice, 'bgra8unorm', 800, 600);
+
+    pass.setBgColor(1, 0.5, 0.2);
+    pass.setThemeMode(1);
+    pass.setGlassRect(10, 20, 100, 200);
+
+    pass.update(16.6, 800, 600);
+
+    expect(mockDevice.queue.writeBuffer).toHaveBeenCalledWith(
+      mockBuffer,
+      0,
+      expect.any(ArrayBuffer)
+    );
+  });
+
+  it('does not draw if not initialized', () => {
+    pass.draw(mockEncoder, {} as GPUTextureView);
+    expect(mockEncoder.beginRenderPass).not.toHaveBeenCalled();
+  });
+
+  it('draws blit pipeline and glass pipeline if glass is set', async () => {
+    await pass.init(mockDevice, 'bgra8unorm', 800, 600);
+    pass.setGlassRect(0, 0, 100, 100);
+
+    pass.draw(mockEncoder, {} as GPUTextureView);
+
+    expect(mockEncoder.beginRenderPass).toHaveBeenCalled();
+    expect(mockPassEncoder.setPipeline).toHaveBeenCalledTimes(2); // Blit + Glass
+    expect(mockPassEncoder.draw).toHaveBeenCalledTimes(2);
+    expect(mockPassEncoder.end).toHaveBeenCalled();
+  });
+
+  it('draws only blit pipeline if glass is not set', async () => {
+    await pass.init(mockDevice, 'bgra8unorm', 800, 600);
+
+    pass.draw(mockEncoder, {} as GPUTextureView);
+
+    expect(mockEncoder.beginRenderPass).toHaveBeenCalled();
+    expect(mockPassEncoder.setPipeline).toHaveBeenCalledTimes(1); // Blit only
+    expect(mockPassEncoder.draw).toHaveBeenCalledTimes(1);
+    expect(mockPassEncoder.end).toHaveBeenCalled();
+  });
+
+  it('destroys resources', async () => {
+    await pass.init(mockDevice, 'bgra8unorm', 800, 600);
+
+    pass.destroy();
+
+    expect(mockTexture.destroy).toHaveBeenCalled();
+    expect(mockBuffer.destroy).toHaveBeenCalled();
   });
 });

--- a/src/features/engine/passes/ContoursPass.test.ts
+++ b/src/features/engine/passes/ContoursPass.test.ts
@@ -1,26 +1,166 @@
-// @vitest-environment node
-import { describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ContoursPass } from './ContoursPass';
+import { GRID_W, GRID_H } from '../core/SimulationConstants';
+import type { SimulationState } from '../core/SimulationState';
 
-const mockPipeline = {
-  getBindGroupLayout: vi.fn(() => ({})),
-};
-
-const mockDevice = {
-  createShaderModule: vi.fn(() => ({})),
-  createRenderPipeline: vi.fn(async () => mockPipeline),
-  createBindGroup: vi.fn(() => ({})),
-  createBuffer: vi.fn(() => ({})),
-  queue: {
-    writeBuffer: vi.fn(),
-  },
-};
+// Mock marchingSquares to avoid complex computation in tests
+vi.mock('../core/MarchingSquares', () => ({
+  marchingSquares: vi.fn().mockImplementation((heightmap, w, h, threshold, out) => {
+    out[0] = 1;
+    out[1] = 2;
+    out[2] = 3;
+    out[3] = 4;
+    return 1; // return 1 segment
+  }),
+}));
 
 describe('ContoursPass', () => {
-  it('initializes pipelines', async () => {
-    const pass = new ContoursPass();
-    // @ts-expect-error
-    await pass.init(mockDevice, 'bgra8unorm', 800, 600);
+  let pass: ContoursPass;
+  let mockDevice: any;
+  let mockPassEncoder: any;
+  let mockVertexBuffer: any;
+  let mockUniformBuffer: any;
+
+  beforeEach(() => {
+    pass = new ContoursPass();
+
+    mockVertexBuffer = {
+      destroy: vi.fn(),
+    };
+
+    mockUniformBuffer = {
+      destroy: vi.fn(),
+    };
+
+    const mockPipeline = {
+      getBindGroupLayout: vi.fn().mockReturnValue({}),
+    };
+
+    mockDevice = {
+      createShaderModule: vi.fn().mockReturnValue({}),
+      createRenderPipeline: vi.fn().mockResolvedValue(mockPipeline),
+      createBuffer: vi.fn((desc: any) => {
+        if (desc.usage & 0x0020) return mockVertexBuffer; // VERTEX
+        return mockUniformBuffer;
+      }),
+      createBindGroup: vi.fn().mockReturnValue({}),
+      queue: {
+        writeBuffer: vi.fn(),
+      },
+    };
+
+    mockPassEncoder = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      setVertexBuffer: vi.fn(),
+      draw: vi.fn(),
+    };
+  });
+
+  it('initializes resources', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    expect(mockDevice.createShaderModule).toHaveBeenCalled();
     expect(mockDevice.createRenderPipeline).toHaveBeenCalled();
+    expect(mockDevice.createBuffer).toHaveBeenCalledTimes(2);
+    expect(mockDevice.createBindGroup).toHaveBeenCalled();
+  });
+
+  it('updates logic correctly', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+    pass.setPalette([[1, 0, 0]]);
+
+    // create a dummy state with some height to trigger the loops
+    const dummyHeightmap = new Float32Array((GRID_W + 1) * (GRID_H + 1));
+    dummyHeightmap[0] = 2.0; // maxH = 2.0
+    const state = { heightmap: dummyHeightmap } as SimulationState;
+
+    // First call frame=1 (skipped due to this.frame % 2 !== 0)
+    pass.update(state, 800, 600);
+    expect(mockDevice.queue.writeBuffer).not.toHaveBeenCalled();
+
+    // Second call frame=2
+    pass.update(state, 800, 600);
+
+    // Check if writeBuffer was called for vertexBuffer and uniformBuffer
+    expect(mockDevice.queue.writeBuffer).toHaveBeenCalledWith(
+      mockVertexBuffer,
+      0,
+      expect.any(ArrayBuffer),
+      0,
+      expect.any(Number)
+    );
+    expect(mockDevice.queue.writeBuffer).toHaveBeenCalledWith(
+      mockUniformBuffer,
+      0,
+      expect.any(ArrayBuffer)
+    );
+  });
+
+  it('skips update if maxH is too small', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const dummyHeightmap = new Float32Array((GRID_W + 1) * (GRID_H + 1));
+    dummyHeightmap[0] = 0.0; // maxH < 1e-6
+    const state = { heightmap: dummyHeightmap } as SimulationState;
+
+    // frame=1
+    pass.update(state, 800, 600);
+    // frame=2
+    pass.update(state, 800, 600);
+
+    expect(mockDevice.queue.writeBuffer).not.toHaveBeenCalled();
+
+    // totalSegs should be 0, draw should not do anything
+    pass.draw(mockPassEncoder);
+    expect(mockPassEncoder.draw).not.toHaveBeenCalled();
+  });
+
+  it('clears segments', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const dummyHeightmap = new Float32Array((GRID_W + 1) * (GRID_H + 1));
+    dummyHeightmap[0] = 2.0;
+    const state = { heightmap: dummyHeightmap } as SimulationState;
+
+    pass.update(state, 800, 600); // frame=1
+    pass.update(state, 800, 600); // frame=2 (writes buffer, totalSegs > 0)
+
+    pass.clear();
+
+    pass.draw(mockPassEncoder);
+    expect(mockPassEncoder.draw).not.toHaveBeenCalled();
+  });
+
+  it('draws correctly', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const dummyHeightmap = new Float32Array((GRID_W + 1) * (GRID_H + 1));
+    dummyHeightmap[0] = 2.0;
+    const state = { heightmap: dummyHeightmap } as SimulationState;
+
+    pass.update(state, 800, 600); // frame=1
+    pass.update(state, 800, 600); // frame=2
+
+    pass.draw(mockPassEncoder);
+
+    expect(mockPassEncoder.setPipeline).toHaveBeenCalled();
+    expect(mockPassEncoder.setBindGroup).toHaveBeenCalled();
+    expect(mockPassEncoder.setVertexBuffer).toHaveBeenCalled();
+    expect(mockPassEncoder.draw).toHaveBeenCalled();
+  });
+
+  it('destroys resources', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    pass.destroy();
+
+    expect(mockVertexBuffer.destroy).toHaveBeenCalled();
+    expect(mockUniformBuffer.destroy).toHaveBeenCalled();
+  });
+
+  it('does nothing on resize', () => {
+    // Just a coverage filler
+    pass.resize(100, 100);
   });
 });

--- a/src/features/engine/passes/FlowPass.test.ts
+++ b/src/features/engine/passes/FlowPass.test.ts
@@ -1,26 +1,153 @@
-// @vitest-environment node
-import { describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { FlowPass } from './FlowPass';
-
-const mockPipeline = {
-  getBindGroupLayout: vi.fn(() => ({})),
-};
-
-const mockDevice = {
-  createShaderModule: vi.fn(() => ({})),
-  createRenderPipeline: vi.fn(async () => mockPipeline),
-  createBindGroup: vi.fn(() => ({})),
-  createBuffer: vi.fn(() => ({})),
-  queue: {
-    writeBuffer: vi.fn(),
-  },
-};
+import { VF_W, VF_H } from '../core/SimulationConstants';
+import type { SimulationState } from '../core/SimulationState';
 
 describe('FlowPass', () => {
-  it('initializes pipelines', async () => {
-    const pass = new FlowPass();
-    // @ts-expect-error
-    await pass.init(mockDevice, 'bgra8unorm', 800, 600);
+  let pass: FlowPass;
+  let mockDevice: any;
+  let mockPassEncoder: any;
+  let mockVertexBuffer: any;
+  let mockUniformBuffer: any;
+
+  beforeEach(() => {
+    pass = new FlowPass();
+
+    mockVertexBuffer = {
+      destroy: vi.fn(),
+    };
+
+    mockUniformBuffer = {
+      destroy: vi.fn(),
+    };
+
+    const mockPipeline = {
+      getBindGroupLayout: vi.fn().mockReturnValue({}),
+    };
+
+    mockDevice = {
+      createShaderModule: vi.fn().mockReturnValue({}),
+      createRenderPipeline: vi.fn().mockResolvedValue(mockPipeline),
+      createBuffer: vi.fn((desc: any) => {
+        if (desc.usage & 0x0020) return mockVertexBuffer; // VERTEX
+        return mockUniformBuffer;
+      }),
+      createBindGroup: vi.fn().mockReturnValue({}),
+      queue: {
+        writeBuffer: vi.fn(),
+      },
+    };
+
+    mockPassEncoder = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      setVertexBuffer: vi.fn(),
+      draw: vi.fn(),
+    };
+  });
+
+  it('initializes resources', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    expect(mockDevice.createShaderModule).toHaveBeenCalled();
     expect(mockDevice.createRenderPipeline).toHaveBeenCalled();
+    expect(mockDevice.createBuffer).toHaveBeenCalledTimes(2);
+    expect(mockDevice.createBindGroup).toHaveBeenCalled();
+  });
+
+  it('updates logic correctly and covers bilinearSample', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+    pass.setPalette([[1, 0, 0]]);
+
+    const dummyVelField = new Float32Array((VF_W + 1) * (VF_H + 1) * 2);
+    // fill the field with positive velocity to trigger the flow logic
+    for (let i = 0; i < dummyVelField.length; i++) {
+      dummyVelField[i] = 1.0;
+    }
+    const state = { velField: dummyVelField } as SimulationState;
+
+    pass.update(state, 800, 600); // frame=1
+    pass.update(state, 800, 600); // frame=2
+
+    // frame=3 (triggers update logic)
+    pass.update(state, 800, 600);
+
+    expect(mockDevice.queue.writeBuffer).toHaveBeenCalledWith(
+      mockVertexBuffer,
+      0,
+      expect.any(ArrayBuffer),
+      0,
+      expect.any(Number)
+    );
+    expect(mockDevice.queue.writeBuffer).toHaveBeenCalledWith(
+      mockUniformBuffer,
+      0,
+      expect.any(ArrayBuffer)
+    );
+  });
+
+  it('handles low velocity in bilinearSample correctly', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const dummyVelField = new Float32Array((VF_W + 1) * (VF_H + 1) * 2);
+    // All 0s so length is < 0.01
+    const state = { velField: dummyVelField } as SimulationState;
+
+    pass.update(state, 800, 600); // frame=1
+    pass.update(state, 800, 600); // frame=2
+    pass.update(state, 800, 600); // frame=3
+
+    // totalSegs should be 0 since length < 0.01 breaks the loop
+    pass.draw(mockPassEncoder);
+    expect(mockPassEncoder.draw).not.toHaveBeenCalled();
+  });
+
+  it('clears segments', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const dummyVelField = new Float32Array((VF_W + 1) * (VF_H + 1) * 2);
+    dummyVelField.fill(1.0);
+    const state = { velField: dummyVelField } as SimulationState;
+
+    pass.update(state, 800, 600); // f1
+    pass.update(state, 800, 600); // f2
+    pass.update(state, 800, 600); // f3 -> generates segments
+
+    pass.clear();
+
+    pass.draw(mockPassEncoder);
+    expect(mockPassEncoder.draw).not.toHaveBeenCalled();
+  });
+
+  it('draws correctly', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const dummyVelField = new Float32Array((VF_W + 1) * (VF_H + 1) * 2);
+    dummyVelField.fill(1.0);
+    const state = { velField: dummyVelField } as SimulationState;
+
+    pass.update(state, 800, 600); // f1
+    pass.update(state, 800, 600); // f2
+    pass.update(state, 800, 600); // f3
+
+    pass.draw(mockPassEncoder);
+
+    expect(mockPassEncoder.setPipeline).toHaveBeenCalled();
+    expect(mockPassEncoder.setBindGroup).toHaveBeenCalled();
+    expect(mockPassEncoder.setVertexBuffer).toHaveBeenCalled();
+    expect(mockPassEncoder.draw).toHaveBeenCalled();
+  });
+
+  it('destroys resources', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    pass.destroy();
+
+    expect(mockVertexBuffer.destroy).toHaveBeenCalled();
+    expect(mockUniformBuffer.destroy).toHaveBeenCalled();
+  });
+
+  it('handles resize', () => {
+    pass.resize(1024, 768);
   });
 });

--- a/src/features/engine/passes/ParticlesPass.test.ts
+++ b/src/features/engine/passes/ParticlesPass.test.ts
@@ -1,26 +1,155 @@
-// @vitest-environment node
-import { describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ParticlesPass } from './ParticlesPass';
 
-const mockPipeline = {
-  getBindGroupLayout: vi.fn(() => ({})),
-};
-
-const mockDevice = {
-  createShaderModule: vi.fn(() => ({})),
-  createRenderPipeline: vi.fn(async () => mockPipeline),
-  createBindGroup: vi.fn(() => ({})),
-  createBuffer: vi.fn(() => ({})),
-  queue: {
-    writeBuffer: vi.fn(),
-  },
-};
-
 describe('ParticlesPass', () => {
-  it('initializes pipelines', async () => {
-    const pass = new ParticlesPass();
-    // @ts-expect-error
-    await pass.init(mockDevice, 'bgra8unorm', 800, 600);
-    expect(mockDevice.createRenderPipeline).toHaveBeenCalled();
+  let pass: ParticlesPass;
+  let mockDevice: any;
+  let mockPassEncoder: any;
+  let mockVertexBuffer: any;
+  let mockUniformBuffer: any;
+
+  beforeEach(() => {
+    pass = new ParticlesPass();
+
+    mockVertexBuffer = {
+      destroy: vi.fn(),
+    };
+
+    mockUniformBuffer = {
+      destroy: vi.fn(),
+    };
+
+    const mockPipeline = {
+      getBindGroupLayout: vi.fn().mockReturnValue({}),
+    };
+
+    mockDevice = {
+      createShaderModule: vi.fn().mockReturnValue({}),
+      createRenderPipeline: vi.fn().mockResolvedValue(mockPipeline),
+      createBuffer: vi.fn((desc: any) => {
+        if (desc.usage & 0x0020) return mockVertexBuffer; // VERTEX
+        return mockUniformBuffer;
+      }),
+      createBindGroup: vi.fn().mockReturnValue({}),
+      queue: {
+        writeBuffer: vi.fn(),
+      },
+    };
+
+    mockPassEncoder = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      setVertexBuffer: vi.fn(),
+      draw: vi.fn(),
+    };
+  });
+
+  it('initializes resources', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    expect(mockDevice.createShaderModule).toHaveBeenCalledTimes(3);
+    expect(mockDevice.createRenderPipeline).toHaveBeenCalledTimes(3);
+    expect(mockDevice.createBuffer).toHaveBeenCalledTimes(6);
+    expect(mockDevice.createBindGroup).toHaveBeenCalledTimes(3);
+  });
+
+  it('updates state and writes to buffers', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const state = {
+      count: 1,
+      particleData: new Float32Array([10, 20, 0, 0, 1, 0, 0, 1]), // x, y, vx, vy, r, g, b, a
+      edgeCount: 1,
+      edgeBuffer: new Float32Array([10, 20, 30, 40, 1, 0, 0, 1, 1, 0, 0, 1]), // x1, y1, x2, y2, c1, c2
+      triCount: 1,
+      triBuffer: new Float32Array(24 * 3), // mock size
+    } as any;
+
+    pass.update(state, 800, 600);
+
+    // Particle, Edge, Tri vertex + uniform buffers writes
+    // Should be 6 writes overall, but the uniform writes are also there.
+    expect(mockDevice.queue.writeBuffer).toHaveBeenCalled();
+  });
+
+  it('handles empty state gracefully', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const state = {
+      count: 0,
+      particleData: new Float32Array(0),
+      edgeCount: 0,
+      edgeBuffer: new Float32Array(0),
+      triCount: 0,
+      triBuffer: new Float32Array(0),
+    } as any;
+
+    mockDevice.queue.writeBuffer.mockClear();
+
+    pass.update(state, 800, 600);
+
+    // Only uniform writes are expected, no vertex buffer writes
+    expect(mockDevice.queue.writeBuffer).toHaveBeenCalledTimes(4);
+  });
+
+  it('draws only when there is count', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const emptyState = { count: 0, edgeCount: 0, triCount: 0 } as any;
+    pass.update(emptyState, 800, 600);
+
+    pass.draw(mockPassEncoder);
+    expect(mockPassEncoder.draw).not.toHaveBeenCalled();
+
+    const state = {
+      count: 1,
+      particleData: new Float32Array(8),
+      edgeCount: 1,
+      edgeBuffer: new Float32Array(12),
+      triCount: 1,
+      triBuffer: new Float32Array(24 * 3),
+    } as any;
+
+    pass.update(state, 800, 600);
+    pass.draw(mockPassEncoder);
+
+    // Triangle(1*3), Edge(4,1), Particle(4,1)
+    expect(mockPassEncoder.draw).toHaveBeenCalledTimes(3);
+  });
+
+  it('clears segments', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    const state = {
+      count: 1,
+      particleData: new Float32Array(8),
+      edgeCount: 1,
+      edgeBuffer: new Float32Array(12),
+      triCount: 1,
+      triBuffer: new Float32Array(24 * 3),
+    } as any;
+    pass.update(state, 800, 600);
+
+    pass.clear();
+
+    pass.draw(mockPassEncoder);
+    expect(mockPassEncoder.draw).not.toHaveBeenCalled();
+  });
+
+  it('destroys resources', async () => {
+    await pass.init(mockDevice, 'bgra8unorm');
+
+    pass.destroy();
+
+    expect(mockVertexBuffer.destroy).toHaveBeenCalledTimes(3);
+    expect(mockUniformBuffer.destroy).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles resize', () => {
+    pass.resize(1024, 768);
+  });
+
+  it('does nothing in setPalette', () => {
+    pass.setPalette([[1, 0, 0]]);
   });
 });

--- a/src/lib/highlighter.test.ts
+++ b/src/lib/highlighter.test.ts
@@ -38,4 +38,13 @@ describe('highlighter logic', () => {
     expect(mockHl.getLoadedLanguages).toHaveBeenCalled();
     expect(mockHl.loadLanguage).toHaveBeenCalledWith('rust');
   });
+
+  it('highlights code when highlighter is ready', async () => {
+    hlModule.setThemes(['github-dark']);
+    await hlModule.getHighlighter();
+
+    const result = hlModule.highlightCode('let x = 1;', 'typescript');
+    expect(result).toContain('<pre class="shiki">');
+    expect(mockHl.codeToHtml).toHaveBeenCalled();
+  });
 });

--- a/src/shared/lib/actions/copy.test.ts
+++ b/src/shared/lib/actions/copy.test.ts
@@ -104,13 +104,34 @@ describe('copy action advanced', () => {
     const node = document.createElement('div');
     node.innerHTML = `
       <pre class="shiki" data-language="text"><code>plain text</code></pre>
+      <pre class="shiki"><code>no lang</code></pre>
       <div data-copy-content="" data-copy-label="Mermaid"></div>
+      <div data-copy-content="YmFzZTY0" data-copy-label="  "></div>
+      <div data-copy-content="YmFzZTY0"></div>
     `;
 
     copy(node);
 
     const buttons = node.querySelectorAll('.copy-btn');
-    expect(buttons).toHaveLength(1);
-    expect(buttons[0]).toHaveTextContent('Copy');
+    expect(buttons).toHaveLength(4);
+    expect(buttons[0]).toHaveTextContent('Copy'); // text lang
+    expect(buttons[1]).toHaveTextContent('Copy'); // missing lang
+    expect(buttons[2]).toHaveTextContent('Copy'); // spaces label
+    expect(buttons[3]).toHaveTextContent('Copy'); // missing label
+  });
+
+  it('falls back to pre.textContent or empty string if no code element', () => {
+    const node = document.createElement('div');
+    node.innerHTML = `
+      <pre class="shiki">just text inside pre</pre>
+      <pre class="shiki"></pre>
+    `;
+    copy(node);
+
+    // The copy logic will still create buttons.
+    // The first one will copy "just text inside pre"
+    // The second one will copy ""
+    const buttons = node.querySelectorAll('.copy-btn');
+    expect(buttons).toHaveLength(2);
   });
 });

--- a/src/shared/lib/actions/focusTrap.test.ts
+++ b/src/shared/lib/actions/focusTrap.test.ts
@@ -35,6 +35,18 @@ describe('focusTrap action', () => {
     expect(document.activeElement).toBe(last);
     expect(preventDefaultShift).toHaveBeenCalled();
 
+    // Case 3: Shift+Tab on last element should do nothing special
+    last.focus();
+    const shiftTabLastEvent = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+    node.dispatchEvent(shiftTabLastEvent);
+    expect(document.activeElement).toBe(last); // Focus stays on last unless browser natively moves it
+
+    // Case 4: Tab on first element should do nothing special
+    first.focus();
+    const tabFirstEvent = new KeyboardEvent('keydown', { key: 'Tab' });
+    node.dispatchEvent(tabFirstEvent);
+    expect(document.activeElement).toBe(first);
+
     document.body.removeChild(node);
   });
 

--- a/src/shared/lib/actions/mermaid.test.ts
+++ b/src/shared/lib/actions/mermaid.test.ts
@@ -92,4 +92,32 @@ describe('mermaid action robust', () => {
     expect(el.dataset.processed).toBeUndefined();
     expect(el.id).toBe('');
   });
+
+  it('updates synchronously when not in browser', async () => {
+    vi.resetModules();
+    vi.doMock('$app/environment', () => ({
+      browser: false,
+    }));
+
+    // dynamically import mermaid to use the mocked browser
+    const { mermaid: mermaidMockedEnv } = await import('./mermaid');
+
+    const node = document.createElement('div');
+    const source = 'graph TD; A-->B;';
+    const b64 = btoa(source);
+    node.innerHTML =
+      '<div class="mermaid" data-processed="true" data-content="' + b64 + '">rendered</div>';
+    document.body.appendChild(node);
+
+    const action = mermaidMockedEnv(node, 'dark');
+    const mermaidLib = (await import('mermaid')).default as MermaidMock;
+    mermaidLib.initialize.mockClear();
+
+    action.update('light');
+
+    // synchronous update should have called initialize immediately
+    expect(mermaidLib.initialize).toHaveBeenCalled();
+
+    vi.doUnmock('$app/environment');
+  });
 });

--- a/src/shared/ui/CopyButton.test.ts
+++ b/src/shared/ui/CopyButton.test.ts
@@ -29,10 +29,15 @@ describe('CopyButton', () => {
     expect(screen.getByText('Copied!')).toBeInTheDocument();
   });
 
-  it('renders inline version correctly', () => {
-    render(CopyButton, { content: 'test', inline: true });
+  it('renders inline version correctly', async () => {
+    render(CopyButton, { content: 'test', inline: true, class: 'extra-class' });
     const button = screen.getByLabelText('Copy');
     expect(button).toHaveClass('copy-btn-inline');
+    expect(button).toHaveClass('extra-class');
     expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+
+    await fireEvent.click(button);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('test');
+    expect(screen.queryByText('Copied!')).not.toBeInTheDocument(); // Still shouldn't be there since inline=true
   });
 });

--- a/src/widgets/search/ui/CommandPalette.test.ts
+++ b/src/widgets/search/ui/CommandPalette.test.ts
@@ -60,4 +60,32 @@ describe('CommandPalette interactions', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     expect(searchModel.open).toBe(false);
   });
+
+  it('toggles on cmd+k / ctrl+k', async () => {
+    vi.spyOn(searchModel, 'openPalette').mockImplementation(async () => {
+      searchModel.open = true;
+    });
+
+    searchModel.open = false;
+    render(CommandPalette);
+
+    // Open
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(searchModel.open).toBe(true);
+
+    // Close
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+    expect(searchModel.open).toBe(false);
+  });
+
+  it('closes on backdrop click', async () => {
+    searchModel.open = true;
+    const { container } = render(CommandPalette);
+
+    const backdrop = container.querySelector('button.fixed.inset-0') as HTMLButtonElement;
+    backdrop.click();
+
+    expect(searchModel.open).toBe(false);
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,7 +59,17 @@ export default defineConfig(({ mode }) => ({
       reporter: process.env.CI ? ['text', 'lcov'] : ['text', 'json', 'html', 'lcov'],
       reportsDirectory: 'target/coverage',
       include: ['src/**/*.ts', 'src/**/*.svelte'],
-      exclude: ['src/**/*.{test,spec}.{js,ts}', 'src/**/*.d.ts', 'src/**/index.ts', 'src/app.html'],
+      exclude: [
+        'src/**/*.{test,spec}.{js,ts}',
+        'src/**/*.d.ts',
+        'src/**/index.ts',
+        'src/app.html',
+        'src/entities/codeTheme/codeTheme.ts',
+        'src/entities/post/api.server.ts',
+        'src/entities/post/post.ts',
+        'src/features/engine/passes/IPass.ts',
+        'src/features/engine/core/SimulationState.ts',
+      ],
     },
   },
 }));


### PR DESCRIPTION
- Add comprehensive unit tests for WebGPU engine passes (Composite, Contours, Flow, Particles)
- Add missing coverage for post API edge cases and copy/mermaid actions
- Exclude interfaces and server-side re-exports from Vitest coverage
- Fix Svelte type-checking error in CompositePass tests
- Remove unused SimulationState import in ParticlesPass tests