### PR TITLE
feat(pipeline): typed PipelineState with explicit read/write

### DIFF
--- a/config/mdsvex/engine/context.js
+++ b/config/mdsvex/engine/context.js
@@ -12,6 +12,15 @@ import { PIPELINE_VERSION } from '../constants.js';
  */
 
 /**
+ * Typed pipeline state shared across passes.
+ * Every key must be explicitly declared so reads/writes are statically traceable.
+ *
+ * @typedef {Object} PipelineState
+ * @property {Set<string>} [knownSlugs]  populated by linksPass setup
+ * @property {Set<string>} [draftSlugs]  populated by linksPass setup
+ */
+
+/**
  * @typedef {Object} BuildContext
  * @property {MarkdownMode} mode
  * @property {string} pipelineVersion
@@ -19,14 +28,14 @@ import { PIPELINE_VERSION } from '../constants.js';
  * @property {Record<string, string>} dependencyVersions
  * @property {Map<string, PostContext>} postContexts
  * @property {ReturnType<typeof createDiagnostics>} diagnostics
- * @property {Record<string, unknown>} state
+ * @property {PipelineState} state
  */
 
 /**
  * @typedef {Object} PostContext
  * @property {string} file
  * @property {ReturnType<typeof createDiagnostics>} diagnostics
- * @property {Record<string, unknown>} state
+ * @property {PipelineState} state
  */
 
 /**
@@ -52,7 +61,7 @@ export function createBuildContext(mode) {
     dependencyVersions: {},
     postContexts: new Map(),
     diagnostics: createDiagnostics(),
-    state: {},
+    state: createPipelineState(),
   };
 }
 
@@ -66,8 +75,40 @@ export function createPostContext(file) {
   return {
     file,
     diagnostics: createDiagnostics(),
-    state: {},
+    state: createPipelineState(),
   };
+}
+
+/**
+ * Create an empty typed pipeline state.
+ * @returns {PipelineState}
+ */
+function createPipelineState() {
+  return {};
+}
+
+/**
+ * Read a value from typed pipeline state.
+ *
+ * @template {keyof PipelineState} K
+ * @param {PipelineState} state
+ * @param {K} key
+ * @returns {PipelineState[K]}
+ */
+export function stateRead(state, key) {
+  return state[key];
+}
+
+/**
+ * Write a value into typed pipeline state.
+ *
+ * @template {keyof PipelineState} K
+ * @param {PipelineState} state
+ * @param {K} key
+ * @param {PipelineState[K]} value
+ */
+export function stateWrite(state, key, value) {
+  state[key] = value;
 }
 
 /**
@@ -77,7 +118,7 @@ export function createPostContext(file) {
  *
  * @param {BuildContext} build
  * @param {string} [filePath]
- * @returns {{ mode: MarkdownMode; diagnostics: ReturnType<typeof createDiagnostics>; state: Record<string, unknown>; registry: typeof markdownComponentRegistry }}
+ * @returns {{ mode: MarkdownMode; diagnostics: ReturnType<typeof createDiagnostics>; state: PipelineState; registry: typeof markdownComponentRegistry }}
  */
 export function resolvePassContext(build, filePath) {
   const postCtx = filePath ? build.postContexts.get(filePath) : undefined;

--- a/config/mdsvex/engine/context.test.js
+++ b/config/mdsvex/engine/context.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBuildContext,
+  createPostContext,
+  resolvePassContext,
+  stateRead,
+  stateWrite,
+} from './context.js';
+import { VALIDATION_MODE } from '../constants.js';
+
+describe('context', () => {
+  describe('createBuildContext', () => {
+    it('creates a build context with typed state', () => {
+      const build = createBuildContext(VALIDATION_MODE.STRICT);
+      expect(build.state).toEqual({});
+      expect(build.diagnostics.list()).toEqual([]);
+    });
+  });
+
+  describe('createPostContext', () => {
+    it('creates a per-post context with typed state', () => {
+      const post = createPostContext('/content/blog/2024/test.md');
+      expect(post.file).toBe('/content/blog/2024/test.md');
+      expect(post.state).toEqual({});
+    });
+  });
+
+  describe('stateRead / stateWrite', () => {
+    it('reads and writes typed state keys', () => {
+      const build = createBuildContext(VALIDATION_MODE.STRICT);
+      const slugs = new Set(['a', 'b']);
+
+      stateWrite(build.state, 'knownSlugs', slugs);
+      expect(stateRead(build.state, 'knownSlugs')).toBe(slugs);
+      expect(stateRead(build.state, 'draftSlugs')).toBeUndefined();
+    });
+  });
+
+  describe('resolvePassContext', () => {
+    it('merges build and post state for resolved files', () => {
+      const build = createBuildContext(VALIDATION_MODE.STRICT);
+      stateWrite(build.state, 'knownSlugs', new Set(['global']));
+
+      const post = createPostContext('/content/blog/2024/post.md');
+      stateWrite(post.state, 'draftSlugs', new Set(['draft']));
+      build.postContexts.set('/content/blog/2024/post.md', post);
+
+      const ctx = resolvePassContext(build, '/content/blog/2024/post.md');
+      expect(stateRead(ctx.state, 'knownSlugs')).toEqual(new Set(['global']));
+      expect(stateRead(ctx.state, 'draftSlugs')).toEqual(new Set(['draft']));
+    });
+
+    it('falls back to build state when file is not tracked', () => {
+      const build = createBuildContext(VALIDATION_MODE.STRICT);
+      stateWrite(build.state, 'knownSlugs', new Set(['fallback']));
+
+      const ctx = resolvePassContext(build, '/content/blog/2024/unknown.md');
+      expect(stateRead(ctx.state, 'knownSlugs')).toEqual(new Set(['fallback']));
+    });
+  });
+});

--- a/config/mdsvex/passes/content/links.js
+++ b/config/mdsvex/passes/content/links.js
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DIAGNOSTIC_CODES, PASS_PHASES, SEVERITY, VALIDATION_MODE } from '../../constants.js';
-import { resolvePassContext } from '../../engine/context.js';
+import { resolvePassContext, stateRead, stateWrite } from '../../engine/context.js';
 
 import { walk } from '../_internal/walk.js';
 
@@ -24,8 +24,8 @@ export function linksPass(options = {}) {
       const metadata = options.knownSlugs
         ? { knownSlugs: options.knownSlugs, draftSlugs: new Set() }
         : getSlugMetadata();
-      build.state.knownSlugs = metadata.knownSlugs;
-      build.state.draftSlugs = metadata.draftSlugs;
+      stateWrite(build.state, 'knownSlugs', metadata.knownSlugs);
+      stateWrite(build.state, 'draftSlugs', metadata.draftSlugs);
     },
     mdsvex(build) {
       return {
@@ -106,7 +106,7 @@ function createLinksRemarkPlugin(build) {
 
 /**
  * @param {MarkdownNode} node
- * @param {{ mode: import('../../engine/context.js').MarkdownMode; diagnostics: ReturnType<typeof import('../../engine/diagnostics.js').createDiagnostics>; state: Record<string, unknown> }} ctx
+ * @param {{ mode: import('../../engine/context.js').MarkdownMode; diagnostics: ReturnType<typeof import('../../engine/diagnostics.js').createDiagnostics>; state: import('../../engine/context.js').PipelineState }} ctx
  * @param {{ path?: string; history?: string[] }} file
  */
 function validateLinkUrl(node, ctx, file) {
@@ -115,8 +115,8 @@ function validateLinkUrl(node, ctx, file) {
 
   if (url.startsWith(BLOG_PATH_PREFIX)) {
     const slug = url.slice(BLOG_PATH_PREFIX.length).split(/[/?#]/)[0];
-    const knownSlugs = /** @type {Set<string>} */ (ctx.state.knownSlugs);
-    const draftSlugs = /** @type {Set<string>} */ (ctx.state.draftSlugs);
+    const knownSlugs = /** @type {Set<string>} */ (stateRead(ctx.state, 'knownSlugs'));
+    const draftSlugs = /** @type {Set<string>} */ (stateRead(ctx.state, 'draftSlugs'));
     if (slug && !knownSlugs.has(slug)) {
       addDiagnostic(ctx, {
         code: DIAGNOSTIC_CODES.BROKEN_INTERNAL_LINK,

--- a/config/mdsvex/passes/content/links.test.js
+++ b/config/mdsvex/passes/content/links.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createBuildContext } from '../../engine/context.js';
+import { createBuildContext, stateWrite } from '../../engine/context.js';
 import { linksPass } from './links.js';
 
 /**
@@ -37,8 +37,8 @@ function createTestContext(mode = 'warn') {
  */
 function getRemarkPlugin(knownSlugs, draftSlugs = new Set()) {
   const build = createTestContext();
-  build.state.knownSlugs = knownSlugs;
-  build.state.draftSlugs = draftSlugs;
+  stateWrite(build.state, 'knownSlugs', knownSlugs);
+  stateWrite(build.state, 'draftSlugs', draftSlugs);
   const plugins = /** @type {any} */ (linksPass({ knownSlugs }).mdsvex)(build).remarkPlugins;
   const plugin = /** @type {any} */ (plugins?.[0]);
   if (typeof plugin !== 'function') {
@@ -57,7 +57,7 @@ describe('links pass', () => {
 
   it('reports broken internal blog links', () => {
     const build = createTestContext();
-    build.state.knownSlugs = new Set(['existing-post']);
+    stateWrite(build.state, 'knownSlugs', new Set(['existing-post']));
     const plugins = /** @type {any} */ (
       linksPass({ knownSlugs: new Set(['existing-post']) }).mdsvex
     )(build).remarkPlugins;
@@ -103,7 +103,7 @@ describe('links pass', () => {
 
   it('ignores external links', () => {
     const build = createTestContext();
-    build.state.knownSlugs = new Set();
+    stateWrite(build.state, 'knownSlugs', new Set());
     const plugins = /** @type {any} */ (linksPass({ knownSlugs: new Set() }).mdsvex)(
       build
     ).remarkPlugins;
@@ -120,7 +120,7 @@ describe('links pass', () => {
 
   it('ignores relative page links', () => {
     const build = createTestContext();
-    build.state.knownSlugs = new Set();
+    stateWrite(build.state, 'knownSlugs', new Set());
     const plugins = /** @type {any} */ (linksPass({ knownSlugs: new Set() }).mdsvex)(
       build
     ).remarkPlugins;
@@ -137,8 +137,8 @@ describe('links pass', () => {
 
   it('reports links to draft posts', () => {
     const build = createTestContext();
-    build.state.knownSlugs = new Set(['draft-post']);
-    build.state.draftSlugs = new Set(['draft-post']);
+    stateWrite(build.state, 'knownSlugs', new Set(['draft-post']));
+    stateWrite(build.state, 'draftSlugs', new Set(['draft-post']));
     const plugins = /** @type {any} */ (linksPass({ knownSlugs: new Set(['draft-post']) }).mdsvex)(
       build
     ).remarkPlugins;


### PR DESCRIPTION
- Replace Record<string, unknown> with PipelineState typedef
- Add knownSlugs and draftSlugs as declared state keys
- Introduce stateRead<K>(state, key) and stateWrite<K>(state, key,
  value) with JSDoc generic typing for compile-time safety
- Update linksPass to use typed read/write instead of direct property
  access
- Add context.test.js covering state merge in resolvePassContext
