### PR TITLE
feat(pipeline): add content-addressed cache for per-post compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build outputs
+/.cache
 /.playwright-mcp
 /.lighthouseci
 /.svelte-kit

--- a/config/mdsvex/build/cache.js
+++ b/config/mdsvex/build/cache.js
@@ -1,0 +1,53 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { PIPELINE_VERSION } from '../constants.js';
+
+const cacheDir = '.cache/mdsvex/posts';
+
+/**
+ * @param {string} filePath
+ * @param {string} content
+ * @returns {string}
+ */
+export function computeCacheKey(filePath, content) {
+	return createHash('sha256').update(`${filePath}\0${content}`).digest('hex');
+}
+
+/**
+ * @param {string} cacheKey
+ * @returns {Promise<{ version: string; post: import('../../../src/entities/post/post').Post; diagnostics: import('../engine/diagnostics.js').Diagnostic[] } | null>}
+ */
+export async function loadCachedPost(cacheKey) {
+	const path = join(cacheDir, `${cacheKey}.json`);
+	if (!existsSync(path)) {
+		return null;
+	}
+	try {
+		const raw = await readFile(path, 'utf8');
+		const cached = JSON.parse(raw);
+		if (cached.version !== PIPELINE_VERSION) {
+			return null;
+		}
+		return cached;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * @param {string} cacheKey
+ * @param {import('../../../src/entities/post/post').Post} post
+ * @param {import('../engine/diagnostics.js').Diagnostic[]} diagnostics
+ */
+export async function saveCachedPost(cacheKey, post, diagnostics) {
+	const path = join(cacheDir, `${cacheKey}.json`);
+	await mkdir(cacheDir, { recursive: true });
+	const payload = {
+		version: PIPELINE_VERSION,
+		post,
+		diagnostics,
+	};
+	await writeFile(path, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}

--- a/config/mdsvex/build/cache.test.js
+++ b/config/mdsvex/build/cache.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { computeCacheKey, loadCachedPost, saveCachedPost } from './cache.js';
+import { PIPELINE_VERSION } from '../constants.js';
+
+describe('content-addressed cache', () => {
+  it('computes deterministic cache keys', () => {
+    const keyA = computeCacheKey('2024/hello.md', 'hello world');
+    const keyB = computeCacheKey('2024/hello.md', 'hello world');
+    const keyC = computeCacheKey('2024/hello.md', 'hello world!');
+    expect(keyA).toBe(keyB);
+    expect(keyA).not.toBe(keyC);
+    expect(keyA).toHaveLength(64);
+  });
+
+  it('returns null for missing cache entries', async () => {
+    const result = await loadCachedPost('nonexistent-key-12345');
+    expect(result).toBeNull();
+  });
+
+  it('round-trips post and diagnostics', async () => {
+    const post = {
+      slug: 'test-post',
+      title: 'Test',
+      created: '2024-01-15',
+      readingTime: 3,
+      contentHash: 'abc123',
+      tags: [],
+    };
+    /** @type {import('../engine/diagnostics.js').Diagnostic[]} */
+    const diagnostics = [
+      { code: 'MDX001', severity: /** @type {const} */ ('warning'), pass: 'test', message: 'Test diagnostic' },
+    ];
+
+    const key = computeCacheKey('2024/test.md', 'content');
+    await saveCachedPost(key, post, diagnostics);
+
+    const cached = await loadCachedPost(key);
+    expect(cached).not.toBeNull();
+    expect(cached?.post.slug).toBe('test-post');
+    expect(cached?.diagnostics).toHaveLength(1);
+    expect(cached?.diagnostics[0].code).toBe('MDX001');
+    expect(cached?.version).toBe(PIPELINE_VERSION);
+  });
+
+  it('invalidates cache on pipeline version mismatch', async () => {
+    const key = computeCacheKey('2024/old.md', 'old content');
+
+    // Manually write an old-version cache file
+    const fs = await import('node:fs/promises');
+    const path = (await import('node:path')).join;
+    const cacheFile = path('.cache/mdsvex/posts', `${key}.json`);
+    await fs.mkdir(path('.cache/mdsvex/posts'), { recursive: true });
+    await fs.writeFile(
+      cacheFile,
+      JSON.stringify({ version: 'v0-old', post: {}, diagnostics: [] }),
+      'utf8'
+    );
+
+    const cached = await loadCachedPost(key);
+    expect(cached).toBeNull();
+  });
+});

--- a/config/mdsvex/build/scan.js
+++ b/config/mdsvex/build/scan.js
@@ -5,6 +5,7 @@ import { join, resolve, relative } from 'node:path';
 import { createPostContext } from '../engine/context.js';
 import { createDiagnostics } from '../engine/diagnostics.js';
 import { validateFrontmatterSchema } from './frontmatter-schema.js';
+import { computeCacheKey, loadCachedPost, saveCachedPost } from './cache.js';
 
 import { DIAGNOSTIC_CODES, RESOURCE_LIMITS, SEVERITY, VALIDATION_MODE } from '../constants.js';
 
@@ -72,6 +73,15 @@ export async function scanPosts(build, config) {
 				});
 			}
 
+			const cacheKey = computeCacheKey(rel, content);
+			const cached = await loadCachedPost(cacheKey);
+			if (cached) {
+				for (const d of cached.diagnostics) {
+					postCtx.diagnostics.add(d);
+				}
+				return { post: cached.post, filePath };
+			}
+
 			const result = await compile(content, config);
 			const data = result?.data;
 			const fm = normalizeFrontmatter(
@@ -105,6 +115,8 @@ export async function scanPosts(build, config) {
 					})
 				)
 			);
+
+			await saveCachedPost(cacheKey, post, postCtx.diagnostics.list());
 			return { post, filePath };
 		})
 	);


### PR DESCRIPTION
- New cache.js: computeCacheKey(filePath + content), load/save cached
  posts
- Cache key is SHA-256 of relative path + raw content
- Cached entries include version (PIPELINE_VERSION), post, and
  diagnostics
- Automatic invalidation when pipeline version changes
- scanPosts restores cached posts to skip mdsvex compile on cache hit
- Add cache.test.js covering determinism, round-trip, and version
  eviction
